### PR TITLE
Fix: Fix Android build by removing expo-blur and adding @react-native-picker/picker

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,13 +9,15 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.sajid.tt"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.sajid.tt"
     },
     "web": {
       "bundler": "metro",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
+    "@react-native-picker/picker": "2.9.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "expo": "~52.0.25",
-    "expo-blur": "~14.0.2",
     "expo-constants": "~17.0.4",
     "expo-font": "~13.0.3",
     "expo-haptics": "~14.0.1",


### PR DESCRIPTION
do remove the node_modules folder and again install the dependencies for it to properly work.